### PR TITLE
fix broken queryPart sorting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,5 +39,5 @@ jobs:
       - run:
           name: Upload coverage
           command: |
-            ./tmp/cc-test-reporter after-build -t gocov --prefix github.com/nuts-foundation/go-leia
+            ./tmp/cc-test-reporter after-build -t gocov --prefix github.com/nuts-foundation/go-leia/v2
 

--- a/plan.go
+++ b/plan.go
@@ -90,10 +90,7 @@ func (f fullTableScanQueryPlan) execute(walker DocumentWalker) error {
 }
 
 func (i indexScanQueryPlan) execute(walker ReferenceScanFn) error {
-	queryParts, err := i.index.QueryPartsOutsideIndex(i.query)
-	if err != nil {
-		return err
-	}
+	queryParts := i.index.QueryPartsOutsideIndex(i.query)
 	if len(queryParts) != 0 {
 		return errors.New("no index with exact match to query found")
 	}
@@ -114,10 +111,7 @@ func (i indexScanQueryPlan) execute(walker ReferenceScanFn) error {
 }
 
 func (i resultScanQueryPlan) execute(walker DocumentWalker) error {
-	queryParts, err := i.index.QueryPartsOutsideIndex(i.query)
-	if err != nil {
-		return err
-	}
+	queryParts := i.index.QueryPartsOutsideIndex(i.query)
 
 	// do the IndexScan
 	return i.collection.db.View(func(tx *bbolt.Tx) error {


### PR DESCRIPTION
fixes #15 

algorithm was wrong and untested. Also notices that `QueryPartsOutsideIndex` (which is dependant on sort) was therefore also wrong. Fixed both and added tests.