### PR TITLE
added NotNil query part

### DIFF
--- a/index_test.go
+++ b/index_test.go
@@ -349,6 +349,23 @@ func TestIndex_Find(t *testing.T) {
 		assert.Equal(t, 1, count)
 	})
 
+	t.Run("ok - not nil", func(t *testing.T) {
+		q := New(NotNil(key))
+		count := 0
+
+		err := db.View(func(tx *bbolt.Tx) error {
+			b := testBucket(t, tx)
+			return i.Iterate(b, q, func(key Reference, value []byte) error {
+				count++
+				return nil
+			})
+		})
+
+		assert.NoError(t, err)
+		// it's a triple index where 4 matching trees exist
+		assert.Equal(t, 4, count)
+	})
+
 	t.Run("ok - match through transformer", func(t *testing.T) {
 		q := New(Eq(key, MustParseScalar("VALUE"))).And(
 			Eq(key2, MustParseScalar("value2"))).And(

--- a/search.go
+++ b/search.go
@@ -128,6 +128,14 @@ func Range(queryPath QueryPath, begin Scalar, end Scalar) QueryPart {
 	}
 }
 
+// NotNil creates a query part where the value must exist.
+// This is done by finding results between byte 0x0 and 0xff
+func NotNil(queryPath QueryPath) QueryPart {
+	return notNilPart{
+		queryPath: queryPath,
+	}
+}
+
 // Prefix creates a query part for a partial match
 // The beginning of a value is matched against the query.
 func Prefix(queryPath QueryPath, value Scalar) QueryPart {
@@ -231,4 +239,24 @@ func (p prefixPart) Condition(key Key, transform Transform) bool {
 	}
 
 	return bytes.HasPrefix(key, transformed.Bytes())
+}
+
+type notNilPart struct {
+	queryPath QueryPath
+}
+
+func (p notNilPart) Equals(other QueryPathComparable) bool {
+	return p.queryPath.Equals(other.QueryPath())
+}
+
+func (p notNilPart) QueryPath() QueryPath {
+	return p.queryPath
+}
+
+func (p notNilPart) Seek() Scalar {
+	return bytesScalar{0x0}
+}
+
+func (p notNilPart) Condition(key Key, _ Transform) bool {
+	return len(key) > 0
 }

--- a/search_test.go
+++ b/search_test.go
@@ -191,3 +191,24 @@ func TestTermPath_Equals(t *testing.T) {
 func TestJSONPath_Equals(t *testing.T) {
 	assert.False(t, NewIRIPath().Equals(NewJSONPath(".")))
 }
+
+func TestNotNilPart_Seek(t *testing.T) {
+	assert.Equal(t, []byte{0}, NotNil(testJsonPath).Seek().value())
+}
+
+func TestNotNilPart_Condition(t *testing.T) {
+	assert.True(t, NotNil(testJsonPath).Condition([]byte{0}, nil))
+	assert.False(t, NotNil(testJsonPath).Condition([]byte{}, nil))
+}
+
+func TestNotNilPart_Equals(t *testing.T) {
+	qp := NotNil(testJsonPath)
+
+	t.Run("true", func(t *testing.T) {
+		assert.True(t, qp.Equals(qp))
+	})
+
+	t.Run("false", func(t *testing.T) {
+		assert.False(t, qp.Equals(NotNil(NewJSONPath("a"))))
+	})
+}

--- a/types.go
+++ b/types.go
@@ -94,6 +94,17 @@ func (fs Float64Scalar) value() interface{} {
 	return float64(fs)
 }
 
+// bytesScalar is used internally for the NotNil query
+type bytesScalar []byte
+
+func (bs bytesScalar) Bytes() []byte {
+	return bs
+}
+
+func (bs bytesScalar) value() interface{} {
+	return bs.Bytes()
+}
+
 // ErrInvalidValue is returned when an invalid value is parsed
 var ErrInvalidValue = errors.New("invalid value")
 


### PR DESCRIPTION
required for checking if a specific claim is available in a verifiable credential. Eg: any VC with an organization name.