### PR TITLE
allow duplicate query paths

### DIFF
--- a/index_integration_test.go
+++ b/index_integration_test.go
@@ -83,6 +83,23 @@ func TestIndex_CursorDynamics(t *testing.T) {
 		assert.Equal(t, 2, found)
 	})
 
+	t.Run("2 docs found on single prefix key using duplicate key", func(t *testing.T) {
+		q := New(Prefix(key1, MustParseScalar("1"))).And(
+			Prefix(key1, MustParseScalar("1")))
+		found := 0
+
+		err := db.View(func(tx *bbolt.Tx) error {
+			b := testBucket(t, tx)
+			return i.Iterate(b, q, func(key Reference, value []byte) error {
+				found++
+				return nil
+			})
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, 2, found)
+	})
+
 	t.Run("2 docs found on prefix key and notNil", func(t *testing.T) {
 		q := New(Prefix(key1, MustParseScalar("1"))).And(NotNil(key2))
 		found := 0


### PR DESCRIPTION
When using query params that had the same path, only one was used. Both inside the index and outside.
This PR changes that. A 2nd or 3rd param that is also in the index are added as additional params that are used in the result scan (just like params outside the index). Duplicate params outside the index are also added.